### PR TITLE
chore(config): Cleaned up the configuration files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,8 +1,11 @@
 # Copyright (c) 2023 MDSANIMA
 
-# https://editorconfig.org
+# This is a configuration file for editor config.
+# Documentation: https://editorconfig.org
+
 
 root = true
+
 
 [*]
 charset = utf-8
@@ -13,47 +16,57 @@ insert_final_newline = true
 max_line_length = 79
 trim_trailing_whitespace = true
 
+
 [*.cmd]
 indent_size = 4
 indent_style = space
+
 
 [*.css]
 indent_size = 4
 indent_style = space
 max_line_length = 120
 
+
 [*.html]
 indent_size = 2
 indent_style = space
 max_line_length = off
+
 
 [*.js]
 indent_size = 2
 indent_style = space
 max_line_length = 120
 
+
 [*.jsx]
 indent_size = 2
 indent_style = space
 max_line_length = 120
+
 
 [*.json]
 indent_size = 2
 indent_style = space
 end_of_line = lf
 
+
 [*.md]
 indent_size = 2
 indent_style = space
+
 
 [*.mjs]
 indent_size = 2
 indent_style = space
 max_line_length = 120
 
+
 [*.ps1]
 indent_size = 4
 indent_style = space
+
 
 [*.py]
 profile = black
@@ -61,64 +74,83 @@ indent_size = 4
 indent_style = space
 max_line_length = 120
 
+
 [*.sh]
 indent_size = 4
 indent_style = space
 
+
 [*.svg]
 insert_final_newline = false
+
 
 [*.ts]
 indent_size = 2
 indent_style = space
 max_line_length = 120
 
+
 [*.tsx]
 indent_size = 2
 indent_style = space
 max_line_length = 120
+
 
 [*.yml]
 indent_size = 2
 indent_style = space
 max_line_length = off
 
+
 [*.yaml]
 indent_size = 2
 indent_style = space
 max_line_length = off
 
+
 [*.zsh]
 indent_size = 4
 indent_style = space
+
+
+[.commitlintrc]
+indent_size = 2
+
 
 [.bashrc]
 indent_size = 4
 indent_style = space
 
+
 [.env*]
 insert_final_newline = false
+
 
 [.eslint*]
 indent_size = 2
 indent_style = space
 max_line_length = 120
 
+
 [.gitconfig]
 indent_size = 4
 indent_style = tab
+
 
 [.zshrc]
 indent_size = 4
 indent_style = space
 
+
 [Makefile]
 indent_size = 4
 indent_style = tab
 
+
 [nginx.conf]
 indent_size = 4
 indent_style = space
+
 
 [pyproject.toml]
 indent_size = 4

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,8 @@
 # Copyright (c) 2023 MDSANIMA
 
+# This is a configuration file for Python package style checking.
+
+
 [flake8]
 max-line-length = 120
 per-file-ignores = *.py: E501

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Copyright (c) 2023 MDSANIMA
 
-# See https://help.github.com/articles/ignoring-files/ for more about ignoring files
+# This is a configuration file for ignoring files on this repository.
+# Documentation: https://help.github.com/articles/ignoring-files/
+
 
 # Python Template
 # Byte-compiled / optimized / DLL files

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,5 +1,8 @@
 # Copyright (c) 2023 MDSANIMA
 
+# This is a configuration file for Python package code linting.
+
+
 [MASTER]
 
 # Add files or directories to the blacklist. They should be base names, not paths.


### PR DESCRIPTION
Cleaning up some docstrings and adding new configurations for the `.commitlintrc` files that specify an indentation size in the editor configuration file.