### PR TITLE
chore(commitlint): changed configuration for subject case

### DIFF
--- a/.commitlintrc
+++ b/.commitlintrc
@@ -16,8 +16,8 @@ rules:
     - kebab-case
   subject-case:
     - 2
-    - always
-    - sentence-case
+    - never
+    - [upper-case, pascal-case, sentence-case, start-case]
   body-case:
     - 2
     - always


### PR DESCRIPTION
I'm going back to standard commit messages that I have been using for years. In them, all letters are lowercase, except for starting the content (body) with a capital letter.