### PR TITLE
chore: Add markdownlint configuration

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,51 @@
+# Maintain a consistent coding style throughout the entire project codebase to
+# ensure readability and maintainability.  Consistent style not only improves
+# collaboration but also makes the code easier to review and debug.
+
+# Linter configuration for Markdown and CommonMark files.  This tool is a style
+# checker that uses a predefined set of rules to check source files for issues
+# such as line length, trailing spaces, indention and more to check and format
+# files based on the CommonMark specification.  It is available as command line
+# tool and work with Prettier for formatting. It can also integrate with your
+# editor to display diagnostics like warnings or errors from the Markdown
+# language server.  These diagnostics are based on the rules defined in this
+# configuration file.  For more information about, refer to the docs and source
+# code, see here: https://github.com/DavidAnson/markdownlint
+
+# The rules are still a work in progress and subject to change.  I still need
+# to think about this configuration, and for now this is a base template.
+
+---
+default: true
+
+# Line length
+MD013: true
+
+# Trailing heading
+MD026:
+  punctuation: .,;:!。，；：！
+
+# Multiple spaces blockquote
+MD027: true
+
+# Inline HTML
+MD033:
+  allowed_elements: [center, details, div, h1, h2, strong, sub, sup, summary]
+
+# Emphasis heading
+MD036:
+  punctuation: .,;:!?。，；：！？
+
+# Link fragments
+MD051: true
+
+# Maximum line length
+line-length:
+  line_length: 80
+  heading_line_length: 64
+  code_block_line_length: 80
+  code_blocks: false
+  tables: false
+  headings: true
+  strict: false
+  stern: false

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,41 @@
+{
+  "endOfLine": "lf",
+  "printWidth": 80,
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 4,
+  "trailingComma": "es5",
+  "overrides": [
+    {
+      "files": "*.md",
+      "excludeFiles": "CHANGELOG.md",
+      "options": {
+        "parser": "markdown",
+        "arrowParens": "always",
+        "bracketSpacing": true,
+        "endOfLine": "lf",
+        "printWidth": 80,
+        "proseWrap": "always",
+        "semi": false,
+        "singleQuote": false,
+        "tabWidth": 2,
+        "trailingComma": "none",
+        "useTabs": false
+      }
+    },
+    {
+      "files": [
+        ".clang*",
+        ".eslint*",
+        ".prettier*",
+        "*.json",
+        "*.yaml",
+        "*.yml",
+        "CHANGELOG.md"
+      ],
+      "options": {
+        "tabWidth": 2
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Added `.markdownlint.yaml` and `.prettierrc` configuration files to establish and maintain uniform coding and Markdown styling conventions across the project.

These configurations enforce rules such as consistent line lengths, the use of semi-colons, and the handling of inline HTML and link fragments in Markdown, ensuring readable and maintainable documentation and codebase. Moreover, revised the `CHANGELOG.md` section header in `.versionrc` for better clarity and readability, aligning with markdownlint's recommendations.

This initiative aims to minimize style discrepancies and improve code readability, facilitating a smoother collaboration process. It is an essential step towards a more structured and efficient development workflow, acknowledging that consistency is key to a project's long-term success.